### PR TITLE
Teams page scrolling / keyboard / safearea fixes

### DIFF
--- a/app/content/profile/index.js
+++ b/app/content/profile/index.js
@@ -8,9 +8,9 @@ import { Link } from "expo-router";
 function Index(props) {
   const user = drillData["users"]["1"];
   const drills = drillData["drills"];
-  const attemptedDrills = Object.keys(drills).filter(
+  const attemptedDrills = user["history"] ? Object.keys(drills).filter(
     (drillId) => drillId in user["history"]
-  );
+  ): [];
   return (
     <ScrollView>
       <ProfileCard user={user} />

--- a/app/content/profile/index.js
+++ b/app/content/profile/index.js
@@ -8,9 +8,9 @@ import { Link } from "expo-router";
 function Index(props) {
   const user = drillData["users"]["1"];
   const drills = drillData["drills"];
-  const attemptedDrills = user["history"] ? Object.keys(drills).filter(
-    (drillId) => drillId in user["history"]
-  ): [];
+  const attemptedDrills = user["history"]
+    ? Object.keys(drills).filter((drillId) => drillId in user["history"])
+    : [];
   return (
     <ScrollView>
       <ProfileCard user={user} />
@@ -19,15 +19,19 @@ function Index(props) {
       </Link>
 
       <Text>Drill History</Text>
-      {attemptedDrills.map((drillId) => {
-        return (
-          <DrillCard
-            drill={drills[drillId]}
-            hrefString={"content/profile/drills/" + drillId}
-            key={drillId}
-          />
-        );
-      })}
+      {user["history"] ? (
+        attemptedDrills.map((drillId) => {
+          return (
+            <DrillCard
+              drill={drills[drillId]}
+              hrefString={"content/profile/drills/" + drillId}
+              key={drillId}
+            />
+          );
+        })
+      ) : (
+        <Text>No drills attempted yet</Text>
+      )}
     </ScrollView>
   );
 }

--- a/app/content/team/index.js
+++ b/app/content/team/index.js
@@ -50,8 +50,17 @@ function Index() {
   }, []);
   return (
     <PaperProvider>
-      <SafeAreaView style={{ flex: 1 }} edges={["right", "top", "left"]}>
-        <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+      <SafeAreaView
+        // flex: without this the scrollview automatically scrolls back up when finger no longer held down
+        style={{ flex: 1 }}
+        // edges: to remove bottom padding above tabbar. Maybe move this (and PaperProvider) into app/_layout.js?
+        edges={["right", "top", "left"]}
+      >
+        <TouchableWithoutFeedback
+          // dismiss keyboard after tapping outside of search bar input
+          onPress={Keyboard.dismiss}
+          accessible={false}
+        >
           <GestureHandlerRootView style={{ flex: 1 }}>
             <Appbar.Header
               statusBarHeight={0}
@@ -154,6 +163,7 @@ function Index() {
 
               <KeyboardAwareScrollView
                 style={{ marginTop: 20, marginLeft: 20 }}
+                // allows opening links from search results without closing keyboard first
                 keyboardShouldPersistTaps="handled"
               >
                 <List.Section>

--- a/app/content/team/index.js
+++ b/app/content/team/index.js
@@ -1,29 +1,31 @@
 import React, { useCallback, useMemo, useRef } from "react";
-import teamData from "~/drill_data.json";
-import { ScrollView, Image, View, Pressable } from "react-native";
+import drillData from "~/drill_data.json";
+import { Image, View, Pressable } from "react-native";
 import {
   Text,
   Button,
-  PaperProvider,
   List,
   Appbar,
   Icon,
   Avatar,
   Searchbar,
+  PaperProvider,
 } from "react-native-paper";
 import { Feather } from "@expo/vector-icons";
-import { Link, router } from "expo-router";
+import { router } from "expo-router";
 import {
   BottomSheetModal,
   BottomSheetModalProvider,
 } from "@gorhom/bottom-sheet";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useNavigation } from "expo-router";
+import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
+import { TouchableWithoutFeedback, Keyboard } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 function Index() {
   const navigation = useNavigation();
-  const users = teamData["users"];
+  const users = drillData["users"];
 
   const [searchQuery, setSearchQuery] = React.useState("");
 
@@ -47,134 +49,151 @@ function Index() {
     console.log("handleSheetChanges", index);
   }, []);
   return (
-    <GestureHandlerRootView style={{ flex: 1 }}>
-      <PaperProvider>
-        <SafeAreaView>
-          <Appbar.Header statusBarHeight={0} style={{ backgroundColor: "FFF" }}>
-            <Appbar.BackAction
-              onPress={() => {
-                navigation.goBack();
-              }}
-              color={"#F24E1E"}
-            />
-            <Appbar.Content title={"Team"} />
-          </Appbar.Header>
-          <BottomSheetModalProvider>
-            <View style={{ alignItems: "center" }}>
-              <Image
-                source={{
-                  uri: "https://upload.wikimedia.org/wikipedia/en/thumb/1/1b/Oregon_State_Beavers_logo.svg/1200px-Oregon_State_Beavers_logo.svg.png",
-                  resizeMode: "contain",
-                  width: 131,
-                  height: 75,
+    <PaperProvider>
+      <SafeAreaView style={{ flex: 1 }} edges={["right", "top", "left"]}>
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+          <GestureHandlerRootView style={{ flex: 1 }}>
+            <Appbar.Header
+              statusBarHeight={0}
+              style={{ backgroundColor: "FFF" }}
+            >
+              <Appbar.BackAction
+                onPress={() => {
+                  navigation.goBack();
                 }}
-                style={{ marginTop: 20 }}
+                color={"#F24E1E"}
               />
-            </View>
-            <View style={{ alignItems: "center" }}>
-              <View
-                style={{
-                  flexDirection: "row",
-                  alignItems: "baseline",
-                }}
-              >
-                <Text style={{ marginTop: 25, fontSize: 30, marginRight: 0 }}>
-                  OSU Golf Team
-                </Text>
-                <Button
-                  onPress={handlePresentModalPress}
-                  size={24}
-                  style={{ width: 10 }}
-                  // react native buttons and icons don't play well together: https://stackoverflow.com/a/70038112
-                  icon={({ size, color }) => (
-                    <Feather name="settings" size={24} color="black"></Feather>
-                  )}
-                ></Button>
-
-                <BottomSheetModal
-                  ref={bottomSheetModalRef}
-                  index={1}
-                  snapPoints={snapPoints}
-                  onChange={handleSheetChanges}
+              <Appbar.Content title={"Team"} />
+            </Appbar.Header>
+            <BottomSheetModalProvider>
+              <View style={{ alignItems: "center" }}>
+                <Image
+                  source={{
+                    uri: "https://upload.wikimedia.org/wikipedia/en/thumb/1/1b/Oregon_State_Beavers_logo.svg/1200px-Oregon_State_Beavers_logo.svg.png",
+                    resizeMode: "contain",
+                    width: 131,
+                    height: 75,
+                  }}
+                  style={{ marginTop: 20 }}
+                />
+              </View>
+              <View style={{ alignItems: "center" }}>
+                <View
+                  style={{
+                    flexDirection: "row",
+                    alignItems: "baseline",
+                  }}
                 >
-                  <View>
-                    <Pressable
-                      onPress={() => {
-                        bottomSheetModalRef.current.close();
-                      }}
-                      //width={"100%"}
-                      //alignItems={"center"}
-                    >
+                  <Text style={{ marginTop: 25, fontSize: 30, marginRight: 0 }}>
+                    OSU Golf Team
+                  </Text>
+                  <Button
+                    onPress={handlePresentModalPress}
+                    size={24}
+                    style={{ width: 10 }}
+                    // react native buttons and icons don't play well together: https://stackoverflow.com/a/70038112
+                    icon={({ size, color }) => (
+                      <Feather
+                        name="settings"
+                        size={24}
+                        color="#F24E1E"
+                        style={{ paddingBottom: 3 }}
+                      ></Feather>
+                    )}
+                  ></Button>
+
+                  <BottomSheetModal
+                    ref={bottomSheetModalRef}
+                    index={1}
+                    snapPoints={snapPoints}
+                    onChange={handleSheetChanges}
+                  >
+                    <View>
+                      <Pressable
+                        onPress={() => {
+                          bottomSheetModalRef.current.close();
+                        }}
+                        //width={"100%"}
+                        //alignItems={"center"}
+                      >
+                        <Text
+                          style={{
+                            textAlign: "left",
+                            marginLeft: 5,
+                            fontSize: 15,
+                            color: "red",
+                          }}
+                        >
+                          Cancel
+                        </Text>
+                      </Pressable>
                       <Text
                         style={{
-                          textAlign: "left",
-                          marginLeft: 5,
-                          fontSize: 15,
-                          color: "red",
+                          textAlign: "center",
+                          fontSize: 20,
+                          marginTop: 20,
                         }}
                       >
-                        Cancel
+                        Team Settings
                       </Text>
-                    </Pressable>
-                    <Text
-                      style={{
-                        textAlign: "center",
-                        fontSize: 20,
-                        marginTop: 20,
-                      }}
-                    >
-                      Team Settings
-                    </Text>
-                  </View>
-                </BottomSheetModal>
+                    </View>
+                  </BottomSheetModal>
+                </View>
               </View>
-            </View>
 
-            <Text style={{ textAlign: "center" }}>
-              {Object.keys(users).length} members
-            </Text>
+              <Text style={{ textAlign: "center" }}>
+                {Object.keys(users).length} members
+              </Text>
 
-            <Searchbar
-              placeholder="Search"
-              onChangeText={onChangeSearch}
-              value={searchQuery}
-              style={{ marginLeft: 20, marginRight: 20, marginTop: 20 }}
-            />
-            <ScrollView style={{ marginTop: 20, marginLeft: 20 }}>
-              <List.Section>
-                {foundUsers.map((user, i) => {
-                  return (
-                    <List.Item
-                      key={user.uid}
-                      title={user.name}
-                      left={() => (
-                        <Avatar.Image
-                          size={24}
-                          source={{
-                            uri: user.pfp,
-                          }}
-                        />
-                      )}
-                      right={() => (
-                        <View
-                          style={{ flexDirection: "row", alignItems: "center" }}
-                        >
-                          <Text>{user.role}</Text>
-                          <Icon source="chevron-right" />
-                        </View>
-                      )}
-                      onPress={() =>
-                        router.push(`content/team/users/${user.uid}`)
-                      }
-                    />
-                  );
-                })}
-              </List.Section>
-            </ScrollView>
-          </BottomSheetModalProvider>
-        </SafeAreaView>
-      </PaperProvider>
-    </GestureHandlerRootView>
+              <Searchbar
+                placeholder="Search"
+                onChangeText={onChangeSearch}
+                value={searchQuery}
+                style={{ marginLeft: 20, marginRight: 20, marginTop: 20 }}
+              />
+
+              <KeyboardAwareScrollView
+                style={{ marginTop: 20, marginLeft: 20 }}
+                keyboardShouldPersistTaps="handled"
+              >
+                <List.Section>
+                  {foundUsers.map((user, i) => {
+                    return (
+                      <List.Item
+                        key={user.uid}
+                        title={user.name}
+                        left={() => (
+                          <Avatar.Image
+                            size={24}
+                            source={{
+                              uri: user.pfp,
+                            }}
+                          />
+                        )}
+                        right={() => (
+                          <View
+                            style={{
+                              flexDirection: "row",
+                              alignItems: "center",
+                            }}
+                          >
+                            <Text>{user.role}</Text>
+                            <Icon source="chevron-right" />
+                          </View>
+                        )}
+                        onPress={() =>
+                          router.push(`content/team/users/${user.uid}`)
+                        }
+                      />
+                    );
+                  })}
+                </List.Section>
+              </KeyboardAwareScrollView>
+            </BottomSheetModalProvider>
+          </GestureHandlerRootView>
+        </TouchableWithoutFeedback>
+      </SafeAreaView>
+    </PaperProvider>
   );
 }
 

--- a/app/content/team/users/[user]/index.js
+++ b/app/content/team/users/[user]/index.js
@@ -10,9 +10,9 @@ function Index(props) {
   const userData = drillData["users"][user_id];
   const drills = drillData["drills"];
   console.log(userData);
-  const attemptedDrills = Object.keys(drills).filter(
+  const attemptedDrills = userData["history"] ? Object.keys(drills).filter(
     (drillId) => drillId in userData["history"]
-  );
+  ): [];
   // console.log(attemptedDrills);
   return (
     <ScrollView>

--- a/app/content/team/users/[user]/index.js
+++ b/app/content/team/users/[user]/index.js
@@ -10,9 +10,9 @@ function Index(props) {
   const userData = drillData["users"][user_id];
   const drills = drillData["drills"];
   console.log(userData);
-  const attemptedDrills = userData["history"] ? Object.keys(drills).filter(
-    (drillId) => drillId in userData["history"]
-  ): [];
+  const attemptedDrills = userData["history"]
+    ? Object.keys(drills).filter((drillId) => drillId in userData["history"])
+    : [];
   // console.log(attemptedDrills);
   return (
     <ScrollView>
@@ -27,15 +27,21 @@ function Index(props) {
       <ProfileCard user={userData} />
 
       <Text>Drill History</Text>
-      {attemptedDrills.map((drillId) => {
-        return (
-          <DrillCard
-            drill={drills[drillId]}
-            hrefString={"/content/team/users/" + userData.uid + "/drills/" + drillId}
-            key={drillId}
-          />
-        );
-      })}
+      {userData["history"] ? (
+        attemptedDrills.map((drillId) => {
+          return (
+            <DrillCard
+              drill={drills[drillId]}
+              hrefString={
+                "/content/team/users/" + userData.uid + "/drills/" + drillId
+              }
+              key={drillId}
+            />
+          );
+        })
+      ) : (
+        <Text>No drills attempted yet</Text>
+      )}
     </ScrollView>
   );
 }

--- a/drill_data.json
+++ b/drill_data.json
@@ -21448,7 +21448,7 @@
     "2": {
       "uid": "2",
       "name": "Tiger Woods",
-      "role": "student",
+      "role": "coach",
       "pfp": "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png",
       "history": {
         "732489": [
@@ -51418,7 +51418,42 @@
           }
         ]
       }
-    }
+    },
+    "4": {
+      "uid": "4",
+      "name": "Test Scroll 4",
+      "role": "student",
+      "pfp": "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png"},
+      "5": {
+        "uid": "5",
+        "name": "Test Scroll 5",
+        "role": "student",
+        "pfp": "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png"},
+        "6": {
+          "uid": "6",
+          "name": "Test Scroll 6",
+          "role": "student",
+          "pfp": "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png"},
+          "7": {
+            "uid": "7",
+            "name": "Test Scroll 7",
+            "role": "student",
+            "pfp": "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png"},
+            "8": {
+              "uid": "8",
+              "name": "Test Scroll 8",
+              "role": "student",
+              "pfp": "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png"},
+              "9": {
+                "uid": "9",
+                "name": "Test Scroll 9",
+                "role": "student",
+                "pfp": "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png"},
+                "10": {
+                  "uid": "10",
+                  "name": "Test Scroll 10",
+                  "role": "student",
+                  "pfp": "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png"}
   },
   "drills": {
     "732489": {


### PR DESCRIPTION
## Changes
- Added more test users to `drill_data.json` to test team page scroll (without history of submissions to avoid clogging up file)
- Handle case where user does not have drill history yet (for both profile and team tabs)
  - ![image](https://github.com/Golf-Drill-Challenge-App/Golf-App/assets/82061589/a9c0eea9-3fb0-43f0-ac37-b3b3e792c098)
    - **Potential TODO**: I opted to just not show anything in drill history, but we could also just not show the user on the list of players, on team index page. Let me know which approach is better.
- I removed some bottom padding introduced by SafeArea flex
  - Further info (including **Potential TODO**): https://github.com/Golf-Drill-Challenge-App/Golf-App/issues/70
- Fix some other issues with keyboard, like adding in keyboardawarescrollview library, allow user to dismiss keyboard by tapping outside of input area, allow user to open links from search result list without closing keyboard first
  - **Potential TODO**: Add these fixes to drill submission input fields, login and signup input, or any other text input components in future