### PR TITLE
Attempt upload to firebase

### DIFF
--- a/app/segments/drill/[id]/submission/input.js
+++ b/app/segments/drill/[id]/submission/input.js
@@ -54,12 +54,6 @@ async function uploadAttempt(outputData) {
     alert(e);
     console.log(e);
   }
-
-  const newAttemptRef = doc(collection(db, "teams", "1", "attempts"));
-
-  const uploadData = { ...outputData, id: newAttemptRef };
-
-  await setDoc(newAttemptRef, uploadData);
 }
 
 /***************************************
@@ -444,7 +438,7 @@ export default function Input({ drillInfo, setToggleResult, setOutputData }) {
                 <Appbar.Action
                   icon="information-outline"
                   onPress={() => {
-                    descriptionModalRef.current?.present();
+                    descriptionModalRef.current ?.present();
                   }}
                   color={"#F24E1E"}
                 />
@@ -494,7 +488,7 @@ export default function Input({ drillInfo, setToggleResult, setOutputData }) {
                       icon={getIconByKey(item.id)}
                       prompt={item.prompt}
                       distanceMeasure={item.distanceMeasure}
-                      inputValue={inputValues[displayedShot]?.[item.id] || ""}
+                      inputValue={inputValues[displayedShot] ?.[item.id] || ""}
                       onInputChange={(newText) => {
                         handleInputChange(item.id, newText);
                       }}
@@ -599,7 +593,7 @@ export default function Input({ drillInfo, setToggleResult, setOutputData }) {
                   <Text
                     style={{ color: "#F3572A" }}
                     onPress={() => {
-                      navModalRef.current?.present();
+                      navModalRef.current ?.present();
                     }}
                   >
                     View all shots

--- a/app/segments/drill/[id]/submission/input.js
+++ b/app/segments/drill/[id]/submission/input.js
@@ -36,20 +36,22 @@ import Description from "./modals/description";
  * Firebase Upload
  ***************************************/
 
-//TODO: Implement function to upload the outputData to the attempts collection
-
+//A function to upload the outputData to the "attempts" collection
 async function uploadAttempt(outputData) {
   try {
     //create new document
     const newAttemptRef = doc(collection(db, "teams", "1", "attempts"));
 
-    console.log("New Attempt Ref: ", newAttemptRef);
-    //add id of new document into the data
-    const uploadData = { ...outputData, id: newAttemptRef };
+    //Newly created doc Id. Useful for finding upload data in testing.
+    console.log("New Attempt Ref ID: ", newAttemptRef.id);
 
-    console.log("Upload Data: ", uploadData);
+    //add id of new document into the data
+    const uploadData = { ...outputData, id: newAttemptRef.id };
+
     //upload the data
     await setDoc(newAttemptRef, uploadData);
+
+    console.log("Document successfully uploaded!");
   } catch (e) {
     alert(e);
     console.log(e);
@@ -438,7 +440,7 @@ export default function Input({ drillInfo, setToggleResult, setOutputData }) {
                 <Appbar.Action
                   icon="information-outline"
                   onPress={() => {
-                    descriptionModalRef.current ?.present();
+                    descriptionModalRef.current?.present();
                   }}
                   color={"#F24E1E"}
                 />
@@ -488,7 +490,7 @@ export default function Input({ drillInfo, setToggleResult, setOutputData }) {
                       icon={getIconByKey(item.id)}
                       prompt={item.prompt}
                       distanceMeasure={item.distanceMeasure}
-                      inputValue={inputValues[displayedShot] ?.[item.id] || ""}
+                      inputValue={inputValues[displayedShot]?.[item.id] || ""}
                       onInputChange={(newText) => {
                         handleInputChange(item.id, newText);
                       }}
@@ -593,7 +595,7 @@ export default function Input({ drillInfo, setToggleResult, setOutputData }) {
                   <Text
                     style={{ color: "#F3572A" }}
                     onPress={() => {
-                      navModalRef.current ?.present();
+                      navModalRef.current?.present();
                     }}
                   >
                     View all shots

--- a/app/segments/drill/[id]/submission/input.js
+++ b/app/segments/drill/[id]/submission/input.js
@@ -4,6 +4,7 @@ import {
   BottomSheetScrollView,
 } from "@gorhom/bottom-sheet";
 import { useLocalSearchParams, useNavigation } from "expo-router";
+import { collection, doc, setDoc } from "firebase/firestore";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Pressable, StyleSheet, View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
@@ -28,6 +29,7 @@ import DrillTarget from "~/components/input/drillTarget";
 import NavigationRectangle from "~/components/input/navigationRectangle";
 import Loading from "~/components/loading";
 import { currentAuthContext } from "~/context/Auth";
+import { db } from "~/firebaseConfig";
 import Description from "./modals/description";
 
 /***************************************
@@ -35,6 +37,30 @@ import Description from "./modals/description";
  ***************************************/
 
 //TODO: Implement function to upload the outputData to the attempts collection
+
+async function uploadAttempt(outputData) {
+  try {
+    //create new document
+    const newAttemptRef = doc(collection(db, "teams", "1", "attempts"));
+
+    console.log("New Attempt Ref: ", newAttemptRef);
+    //add id of new document into the data
+    const uploadData = { ...outputData, id: newAttemptRef };
+
+    console.log("Upload Data: ", uploadData);
+    //upload the data
+    await setDoc(newAttemptRef, uploadData);
+  } catch (e) {
+    alert(e);
+    console.log(e);
+  }
+
+  const newAttemptRef = doc(collection(db, "teams", "1", "attempts"));
+
+  const uploadData = { ...outputData, id: newAttemptRef };
+
+  await setDoc(newAttemptRef, uploadData);
+}
 
 /***************************************
  * AttemptShots Generation
@@ -328,7 +354,7 @@ export default function Input({ drillInfo, setToggleResult, setOutputData }) {
             );
 
             setOutputData(outputData);
-            //send the output data to the database here
+            uploadAttempt(outputData);
             setToggleResult(true);
           }}
         >

--- a/app/segments/drill/[id]/submission/input.js
+++ b/app/segments/drill/[id]/submission/input.js
@@ -137,7 +137,7 @@ function createOutputData(
   uid,
   did,
   outputs,
-  aggOutputs,
+  aggOutputsObj,
 ) {
   //initialize total values
   let strokesGainedTotal = 0;
@@ -241,6 +241,7 @@ function createOutputData(
     shots: outputShotData,
   };
 
+  const aggOutputs = Object.keys(aggOutputsObj);
   //Generate the aggOutputs for output data
   for (let i = 0; i < aggOutputs.length; i++) {
     const aggOutput = aggOutputs[i];
@@ -277,9 +278,7 @@ function createOutputData(
     }
   }
 
-  return {
-    outputData,
-  };
+  return outputData;
 }
 
 export default function Input({ drillInfo, setToggleResult, setOutputData }) {

--- a/app/segments/drill/[id]/submission/input.js
+++ b/app/segments/drill/[id]/submission/input.js
@@ -49,9 +49,9 @@ async function uploadAttempt(outputData) {
     const uploadData = { ...outputData, id: newAttemptRef.id };
 
     //upload the data
-    await setDoc(newAttemptRef, uploadData);
-
-    console.log("Document successfully uploaded!");
+    await setDoc(newAttemptRef, uploadData).then(() => {
+      console.log("Document successfully uploaded!");
+    });
   } catch (e) {
     alert(e);
     console.log(e);

--- a/app/segments/drill/[id]/submission/result.js
+++ b/app/segments/drill/[id]/submission/result.js
@@ -13,7 +13,7 @@ import ShotAccordion from "~/components/shotAccordion";
 import { numTrunc } from "~/Utility";
 
 function Result(props) {
-  const submission = props.submission.outputData;
+  const submission = props.submission;
   const navigation = useNavigation();
   const drillId = useLocalSearchParams()["id"];
 


### PR DESCRIPTION
### Issue
The current implementation was not uploading the results from an attempt to the database. This would mean after each attempt, all the attempt data was lost. 
**Related Issue:** #89 

### Changes
Created a function that will does the following:
- Takes in outputData
- Creates a new document in the "attempts" collection
- Appends the ID of the the new document with outputData which creates uploadData
- Updates the new document with uploadData

### Other Notes
- Currently there is a log message for the new document ID which can be used to validate an attempt has been uploaded through finding it on the firebase console