### PR TITLE
Strokes gained fix

### DIFF
--- a/Utility.js
+++ b/Utility.js
@@ -128,6 +128,10 @@ export function lookUpBaselineStrokesGained(value) {
       return sgValues[i - 1];
     }
   }
+  console.log(
+    "Distance Exceeded ceiling of strokes gained in lookUpBaselineStrokesGained",
+  );
+  return sgValues[sgValues.length - 1];
 }
 export function lookUpExpectedPutts(proxHole) {
   const putt_keys = [


### PR DESCRIPTION
### Changes
Simply returns the max value of strokes gained when the range of keys is exceed within the lookUpBaselineStrokesGained function. This is to ensure uploading will always have a number and nothing will undefined. 

**Related Issue:** Closes #100 