### PR TITLE
Frankreed/Prevent leave dialog bypass in submit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /.vs
 /venv
 eas.json
+ios
+android
+webstorm.config.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,5 @@ assets
 venv
 .expo
 .idea
+ios
+android

--- a/app/segments/drill/[id]/submission/index.js
+++ b/app/segments/drill/[id]/submission/index.js
@@ -1,5 +1,5 @@
-import { useLocalSearchParams } from "expo-router";
-import { useState } from "react";
+import { useLocalSearchParams, useNavigation } from "expo-router";
+import { useEffect, useState } from "react";
 import { DefaultTheme, PaperProvider } from "react-native-paper";
 
 import Loading from "~/components/loading";
@@ -8,12 +8,37 @@ import Result from "./result";
 
 import ErrorComponent from "~/components/errorComponent";
 import { useDrillInfo } from "~/hooks/useDrillInfo";
+import DialogComponent from "../../../../../components/dialog";
 
 export default function Index() {
   const { id } = useLocalSearchParams();
 
   const [outputData, setOutputData] = useState([]);
   const [toggleResult, setToggleResult] = useState(false);
+  const [leaveDialogVisible, setLeaveDialogVisible] = useState(false);
+  const hideLeaveDialog = () => setLeaveDialogVisible(false);
+
+  const [exitAction, setExitAction] = useState(null);
+  // Navigation
+  const navigation = useNavigation();
+
+  navigation.setOptions({ gestureEnabled: toggleResult });
+  useEffect(
+    () =>
+      navigation.addListener("beforeRemove", (e) => {
+        if (toggleResult) {
+          return;
+        }
+        // Prevent default behavior of leaving the screen
+        e.preventDefault();
+
+        setExitAction(e.data.action);
+
+        // Prompt the user before leaving the screen
+        setLeaveDialogVisible(true);
+      }),
+    [navigation, toggleResult],
+  );
 
   const {
     data: drillInfo,
@@ -45,5 +70,25 @@ export default function Index() {
     }
   };
 
-  return <PaperProvider theme={DefaultTheme}>{display()}</PaperProvider>;
+  return (
+    <PaperProvider theme={DefaultTheme}>
+      {display()}
+
+      {/* Leave Drill Dialog */}
+      <DialogComponent
+        title={"Alert"}
+        content="All inputs will be lost."
+        visible={leaveDialogVisible}
+        onHide={hideLeaveDialog}
+        buttons={["Cancel", "Leave Drill"]}
+        buttonsFunctions={[
+          hideLeaveDialog,
+          () => {
+            hideLeaveDialog();
+            navigation.dispatch(exitAction);
+          },
+        ]}
+      />
+    </PaperProvider>
+  );
 }

--- a/app/segments/drill/[id]/submission/index.js
+++ b/app/segments/drill/[id]/submission/index.js
@@ -6,9 +6,9 @@ import Loading from "~/components/loading";
 import Input from "./input";
 import Result from "./result";
 
+import DialogComponent from "~/components/dialog";
 import ErrorComponent from "~/components/errorComponent";
 import { useDrillInfo } from "~/hooks/useDrillInfo";
-import DialogComponent from "../../../../../components/dialog";
 
 export default function Index() {
   const { id } = useLocalSearchParams();
@@ -22,23 +22,24 @@ export default function Index() {
   // Navigation
   const navigation = useNavigation();
 
-  navigation.setOptions({ gestureEnabled: toggleResult });
-  useEffect(
-    () =>
-      navigation.addListener("beforeRemove", (e) => {
-        if (toggleResult) {
-          return;
-        }
-        // Prevent default behavior of leaving the screen
-        e.preventDefault();
+  useEffect(() => {
+    navigation.setOptions({ gestureEnabled: toggleResult });
+  }, [toggleResult]);
 
-        setExitAction(e.data.action);
+  useEffect(() => {
+    return navigation.addListener("beforeRemove", (e) => {
+      if (toggleResult) {
+        return;
+      }
+      // Prevent default behavior of leaving the screen
+      e.preventDefault();
 
-        // Prompt the user before leaving the screen
-        setLeaveDialogVisible(true);
-      }),
-    [navigation, toggleResult],
-  );
+      setExitAction(e.data.action);
+
+      // Prompt the user before leaving the screen
+      setLeaveDialogVisible(true);
+    });
+  }, []);
 
   const {
     data: drillInfo,

--- a/app/segments/drill/[id]/submission/index.js
+++ b/app/segments/drill/[id]/submission/index.js
@@ -39,7 +39,7 @@ export default function Index() {
       // Prompt the user before leaving the screen
       setLeaveDialogVisible(true);
     });
-  }, []);
+  }, [toggleResult]);
 
   const {
     data: drillInfo,

--- a/app/segments/drill/[id]/submission/input.js
+++ b/app/segments/drill/[id]/submission/input.js
@@ -709,14 +709,14 @@ export default function Input({ drillInfo, setToggleResult, setOutputData }) {
                 </BottomSheetScrollView>
               </BottomSheetModal>
 
-                {/* Error Dialog: Empty Input*/}
-                <DialogComponent
-                  type={"snackbar"}
-                  title={"Error!"}
-                  content="All inputs must be filled."
-                  visible={emptyDialogVisible}
-                  onHide={hideEmptyDialog}
-                />
+              {/* Error Dialog: Empty Input*/}
+              <DialogComponent
+                type={"snackbar"}
+                title={"Error!"}
+                content="All inputs must be filled."
+                visible={emptyDialogVisible}
+                onHide={hideEmptyDialog}
+              />
 
               {/* Error Dialog: Invalid Input*/}
               <DialogComponent

--- a/app/segments/drill/[id]/submission/input.js
+++ b/app/segments/drill/[id]/submission/input.js
@@ -463,10 +463,6 @@ export default function Input({ drillInfo, setToggleResult, setOutputData }) {
 
   const descriptionModalRef = useRef(null);
 
-  /***** Leave drill Dialog Stuff *****/
-  const [leaveDialogVisible, setLeaveDialogVisible] = useState(false);
-  const hideLeaveDialog = () => setLeaveDialogVisible(false);
-
   /***** Empty Input dialog Stuff *****/
   const [emptyDialogVisible, setEmptyDialogVisible] = useState(false);
   const hideEmptyDialog = () => setEmptyDialogVisible(false);
@@ -597,7 +593,7 @@ export default function Input({ drillInfo, setToggleResult, setOutputData }) {
               preChildren={
                 <Appbar.Action
                   icon="close"
-                  onPress={() => setLeaveDialogVisible(true)}
+                  onPress={() => navigation.goBack()}
                   color={themeColors.accent}
                 />
               }
@@ -713,30 +709,14 @@ export default function Input({ drillInfo, setToggleResult, setOutputData }) {
                 </BottomSheetScrollView>
               </BottomSheetModal>
 
-              {/* Leave Drill Dialog */}
-              <DialogComponent
-                title={"Alert"}
-                content="All inputs will be lost."
-                visible={leaveDialogVisible}
-                onHide={hideLeaveDialog}
-                buttons={["Cancel", "Leave Drill"]}
-                buttonsFunctions={[
-                  hideLeaveDialog,
-                  () => {
-                    hideLeaveDialog;
-                    navigation.goBack();
-                  },
-                ]}
-              />
-
-              {/* Error Dialog: Empty Input*/}
-              <DialogComponent
-                type={"snackbar"}
-                title={"Error!"}
-                content="All inputs must be filled."
-                visible={emptyDialogVisible}
-                onHide={hideEmptyDialog}
-              />
+                {/* Error Dialog: Empty Input*/}
+                <DialogComponent
+                  type={"snackbar"}
+                  title={"Error!"}
+                  content="All inputs must be filled."
+                  visible={emptyDialogVisible}
+                  onHide={hideEmptyDialog}
+                />
 
               {/* Error Dialog: Invalid Input*/}
               <DialogComponent


### PR DESCRIPTION
Before, the "Leave Drill" dialog can be circumvented by swiping back (iOS), and pressing the back button (Android). This fixes all of that