### PR TITLE
Fix leaderboard rank and Pfp alignment

### DIFF
--- a/app/content/drill/[id]/leaderboard.js
+++ b/app/content/drill/[id]/leaderboard.js
@@ -170,11 +170,10 @@ export default function Leaderboard() {
                   <View
                     style={{
                       flexDirection: "row",
-
-                      padding: 6,
+                      alignItems: "center",
                     }}
                   >
-                    <Text style={{ marginRight: 10, alignSelf: "center" }}>
+                    <Text style={{ width: 30 }}>
                       {leaderboardRanks[idx].toString()}.
                     </Text>
                     <Avatar.Text size={24} label="XD" />


### PR DESCRIPTION
### Description
A small change to fix the alignment of pfp on the leaderboard. 

### Screenshots:

**Old**
![image](https://github.com/Golf-Drill-Challenge-App/Golf-App/assets/91503842/5c1c1dbd-57c8-431c-a097-993b000cb724)

**New with 2 digits**
![image](https://github.com/Golf-Drill-Challenge-App/Golf-App/assets/91503842/33ef73f4-13ce-42a1-b3b4-dbd2b8b5785e)

**New with 3 digits**
![image](https://github.com/Golf-Drill-Challenge-App/Golf-App/assets/91503842/d95aeb68-de26-4235-9ec2-781c34df12d5)
 