### PR TITLE
Login and Assignments Bug Fixes

### DIFF
--- a/app/(auth)/signin.js
+++ b/app/(auth)/signin.js
@@ -17,6 +17,7 @@ import {
 } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import { themeColors } from "~/Constants";
+import { currentAuthContext } from "~/context/Auth";
 import { auth } from "~/firebaseConfig";
 
 const BUTTON_WIDTH = 150;
@@ -25,13 +26,20 @@ const INPUT_WIDTH = 200;
 export default function SignIn() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const { setCurrentUserId } = currentAuthContext();
 
   async function handleSignIn() {
-    try {
-      await signInWithEmailAndPassword(auth, email, password);
-    } catch (e) {
-      alert(e);
-      console.log(e);
+    if (process.env.EXPO_PUBLIC_TEST_UID) {
+      // Only allow login as test user while using `yarn test` to reduce errors
+      setCurrentUserId(process.env.EXPO_PUBLIC_TEST_UID);
+      console.log("user changed. userId:", process.env.EXPO_PUBLIC_TEST_UID);
+    } else {
+      try {
+        await signInWithEmailAndPassword(auth, email, password);
+      } catch (e) {
+        alert(e);
+        console.log(e);
+      }
     }
   }
 

--- a/app/content/assignments/index.js
+++ b/app/content/assignments/index.js
@@ -1,6 +1,6 @@
 import { router } from "expo-router";
 import { useState } from "react";
-import { SectionList, TouchableOpacity, View } from "react-native";
+import { LogBox, SectionList, TouchableOpacity, View } from "react-native";
 import { Icon, List, Text } from "react-native-paper";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { themeColors } from "~/Constants";
@@ -16,7 +16,7 @@ import { useDrillInfo } from "~/hooks/useDrillInfo";
 import { useUserInfo } from "~/hooks/useUserInfo";
 
 const DrillList = () => {
-  const { currentUserId } = currentAuthContext();
+  const { currentUserId, currentTeamId } = currentAuthContext();
 
   const {
     data: drillInfo,
@@ -32,6 +32,22 @@ const DrillList = () => {
 
   const userId = currentUserId;
   const invalidateKeys = [["user", { userId }], ["drillInfo"]];
+
+  // Handle both errors of 'cannot read property "reduce" of undefined' and
+  // 'data is undefined' / 'Query data cannot be undefined' (useUserInfo hook error)
+  if (
+    !currentUserId ||
+    (userInfoError && String(userInfoError).includes("data is undefined"))
+  ) {
+    // The logs still show up on the console (which is probably good), just hidden from phone screen
+    LogBox.ignoreLogs(["Query data cannot be undefined"]);
+    return (
+      <EmptyScreen
+        invalidateKeys={invalidateKeys}
+        text={"No drills assigned"}
+      />
+    );
+  }
 
   if (userIsLoading || drillInfoIsLoading) {
     return <Loading />;

--- a/app/content/profile/index.js
+++ b/app/content/profile/index.js
@@ -134,12 +134,12 @@ function Index() {
     signoutFireBase(auth)
       .then(() => {
         // Sign-out successful.
+        signOut();
       })
       .catch((e) => {
         alert(e);
         console.log(e);
       });
-    signOut();
   }
 
   const resetForm = () => {

--- a/context/Auth.js
+++ b/context/Auth.js
@@ -45,18 +45,19 @@ export const AuthProvider = ({ children }) => {
   useEffect(() => {
     //if this code is not in here, it'll run for infinite times
     onAuthStateChanged(auth, (currentUserId) => {
-      console.log("user changed. userId: ", currentUserId["uid"]);
-
       // test user login (yarn test)
-      // If you sign out, reload app to sign back in as test user
+      // If you sign out, reload or click "sign in" to login as test user
+      // Signout functionality for test user is buggy, chance of auto-logging back in
       if (process.env.EXPO_PUBLIC_TEST_UID) {
         setCurrentUserId(process.env.EXPO_PUBLIC_TEST_UID);
+        console.log("user changed. userId:", process.env.EXPO_PUBLIC_TEST_UID);
       }
 
       // regular user login
       else {
         if (currentUserId) {
-          setCurrentUserId(currentUserId.uid ?? "Error (uid)");
+          setCurrentUserId(currentUserId["uid"] ?? "Error (uid)");
+          console.log("user changed. userId:", currentUserId["uid"]);
         }
       }
     });
@@ -67,14 +68,11 @@ export const AuthProvider = ({ children }) => {
         currentUserId: currentUserId,
         setCurrentUserId: (uidvar) => {
           setCurrentUserId(uidvar ?? "Error (uid)");
-          // console.log(currentUserId);
         },
-        // setCurrentUserId({ name: "Test", email: "test@example.com", type: type }),
         signOut: () => setCurrentUserId(null),
         currentTeamId,
         setCurrentTeamId: (tidvar) => {
           setCurrentTeamId(tidvar ?? "Error (tid)");
-          // console.log(currentTeamId);
         },
       }}
     >


### PR DESCRIPTION
## Fixed Bugs (non exhaustive)
Test bugs on layout branch first if you want to replicate bugs, otherwise they should be fixed on this branch
- `Cannot read property 'uid' of null` (test user login fix)
  - ![image](https://github.com/Golf-Drill-Challenge-App/Golf-App/assets/82061589/cb582d1f-7846-43ec-aeeb-bd944ca070d0)
  - Testing (layout branch): Launch app via `yarn start`, signout, double swipe up on Expo app on phone, kill terminal via Ctrl / Cmd C, relaunch app via `yarn test`
  - Resolved by just putting the console log statement that tried to check `currentUserId["uid"]` behind an if statement
- `Cannot read property 'reduce' of undefined`
  - https://github.com/Golf-Drill-Challenge-App/Golf-App/issues/193 (see first screenshot)
  - Triggered on assignments tab index page
  - Testing (layout branch): Triggered randomly when signing out with a newly created user (as mentioned by Jake in Issue 193). Can also happen when logging out of test user on layout branch.
  - Resolved by just doing an early return statement with EmptyScreen component if `userId` is undefined (so that the `reduce` code is never reached)
- "query data cannot be undefined"
  - https://github.com/Golf-Drill-Challenge-App/Golf-App/issues/148
  - Thought it was fixed but it still triggers the error within EmptyScreen component
  - Testing (layout branch): Sign up as new user, you will get error after logging in
  - Resolved by just doing an early return statement with EmptyScreen component if the error string is detected, and also hiding the error popup (maybe there is better way to fix this than hiding it)
- Test user signout race condition
  - Testing (layout branch): Launch app via `yarn start`, sign in as regular user. Without signing out, double swipe up on Expo app on phone, kill terminal via Ctrl / Cmd C, relaunch app via `yarn test`, and then try to sign out this time. You will auto log back in due to some race condition.
  - Resolved by moving `signOut` function (the one calling currentAuthContext) into the `.then` of `signoutFirebase` function (the one that logs out actual users from Firebase) in Profile Index page (so that the 2 signout functions do not conflict).
  - Seems to log out whichever user you used in `yarn start` while in `yarn test`, which could be good for debugging broken / older user accounts