### PR TITLE
update readme headings / grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,25 @@
 
 Cross Platform Mobile app for the OSU Men's Golf Team.
 
+## Landing Page
+
+- https://golf-drill-challenge-app.github.io/
+  - Will add more user-facing documentation pages (FAQ) here in the future if needed
+
 ## Tech Stack
 
 - [React Native](https://reactnative.dev/)
 - [React Native Paper](https://reactnativepaper.com/)
 - [React Native SVG Charts](https://www.npmjs.com/package/react-native-svg-charts)
 - [Expo Go](https://expo.dev/)
+- [TanStack Query](https://tanstack.com/query/latest/docs/framework/react/overview)
 - [Firestore](https://firebase.google.com/docs/firestore)
 
 See [package.json](package.json) for more details on libraries used
+
+### Architecture Diagram
+
+![architectural_diagram](https://i.imgur.com/Wy0O2iL.png)
 
 ## Design References
 
@@ -59,11 +69,12 @@ Compatible with both MacOS and Windows PC for app compilation.
 - Command to run Android Emulator:
   - `C:\Users\<username>\AppData\Local\Android\Sdk\emulator\emulator -avd <emulated phone name> -feature -Vulkan`
     - Example: `C:\Users\solde\AppData\Local\Android\Sdk\emulat-or\emulator -avd Pixel_3a_API_34_extension_level_7_x86_64 -feature -Vulkan`
+    - Add `-no-snapshot-load` flag to start emulator from "cold boot" (if emulator keeps crashing upon turning on)
 - `yarn a` to run the app
 
 ### Dev Mode Instructions for iOS Emulator
 
-Probably needs MacOS for app compilation (to run XCode) / iOS Emulator.
+Needs MacOS for app compilation (to run XCode) / iOS Emulator.
 
 - Note that Expo Go will be automatically installed on the emulated mobile device for you
 - Documentation: https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device
@@ -93,7 +104,7 @@ Probably needs MacOS for app compilation (to run XCode) / iOS Emulator.
 
 ### Prebuild Instructions for Android (Production Mode)
 
-Presumably compatible with both MacOS and Windows PC for building the project in Android Studio.
+Compatible with both MacOS and Windows PC for building the project in Android Studio.
 
 - `yarn prebuild`
 - `yarn android`
@@ -103,7 +114,7 @@ Presumably compatible with both MacOS and Windows PC for building the project in
 
 ### Prebuild Instructions for iOS (Production Mode, needs MacOS)
 
-Probably needs a MacOS at least for building the project in XCode.
+Needs a MacOS for building the project in XCode.
 
 - `yarn prebuild`
 - `yarn ios`

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ See [package.json](package.json) for more details on libraries used
 - Golf Coach's Spreadsheets (sample golf drills / calculations)
   - [Approach Shots / Line Tests](https://docs.google.com/spreadsheets/d/1ZufXjRCTzbIqJln_fJ5NDvNo0ahHIM-bkv9ZB8a6Drw/edit#gid=259638677)
   - [Putting](https://docs.google.com/spreadsheets/d/12gnHaMyzP0eGAi3MGVBYaG5obCJ0xri9d0RiqiWKfuA/edit#gid=865463318)
+  - [Full List of Golf Drills](https://docs.google.com/spreadsheets/d/1wzSL7WhsdgXudPROZLy6gyYUY910k_wEY-bWuKE_brk/edit#gid=0)
 - [Data Golf](https://datagolf.com/player-profiles?dg_id=18841)
   - Example of graph logic / styling, for golf stats
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,17 @@ Info below subject to change
 
 ### Dev Mode Instructions for Physical Mobile Device
 
+Compatible with both MacOS and Windows PC for app compilation. After compilation, app can be run on either iOS or Android phone.
+
 - Install Expo Go mobile app to run the app dev build
   - [iOS](https://apps.apple.com/us/app/expo-go/id982107779)
   - [Android](https://play.google.com/store/apps/details?id=host.exp.exponent&hl=en_US&gl=US)
 - `yarn start`
   - Run app, scan QR code on physical phone
 
-### Dev Mode Instructions for Android Emulator (Windows PC or MacOS)
+### Dev Mode Instructions for Android Emulator
+
+Compatible with both MacOS and Windows PC for app compilation.
 
 - Note that Expo Go will be automatically installed on the emulated mobile device for you
 - Create an Android Emulator AVD (simulated phone): https://developer.android.com/studio/run/managing-avds
@@ -54,10 +58,12 @@ Info below subject to change
   - More info: https://developer.android.com/studio/run/emulator-troubleshooting#error:-%60vulkan-1.dll
 - Command to run Android Emulator:
   - `C:\Users\<username>\AppData\Local\Android\Sdk\emulator\emulator -avd <emulated phone name> -feature -Vulkan`
-    - Example: `C:\Users\solde\AppData\Local\Android\Sdk\emulator\emulator -avd Pixel_3a_API_34_extension_level_7_x86_64 -feature -Vulkan`
+    - Example: `C:\Users\solde\AppData\Local\Android\Sdk\emulat-or\emulator -avd Pixel_3a_API_34_extension_level_7_x86_64 -feature -Vulkan`
 - `yarn a` to run the app
 
-### Dev Mode Instructions for iOS Emulator (MacOS)
+### Dev Mode Instructions for iOS Emulator
+
+Probably needs MacOS for app compilation (to run XCode) / iOS Emulator.
 
 - Note that Expo Go will be automatically installed on the emulated mobile device for you
 - Documentation: https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device
@@ -85,9 +91,9 @@ Info below subject to change
       - For running app on iOS or Android emulator
     - Note that arguments can be combined, e.g. `yarn test --android --tunnel`
 
-### Building for Production Mode (Prebuild)
+### Prebuild Instructions for Android (Production Mode)
 
-**Android**
+Presumably compatible with both MacOS and Windows PC for building the project in Android Studio.
 
 - `yarn prebuild`
 - `yarn android`
@@ -95,10 +101,12 @@ Info below subject to change
   - Open Android Studio and build APK
   - Load it onto your phone
 
-**iOS**
+### Prebuild Instructions for iOS (Production Mode, needs MacOS)
+
+Probably needs a MacOS at least for building the project in XCode.
 
 - `yarn prebuild`
-- `yarn android`
+- `yarn ios`
 - Steps (to be fleshed out later):
   - Open `xcworkspace` in XCode
   - Go to `Product` > `Archive`
@@ -114,7 +122,7 @@ Info below subject to change
   - NOTE: This will automatically update any files with the reformatted version; if you just want to check for possible formatting issues, run `yarn pretty:check` (see below)
 - `yarn pretty:check`
   - Runs Prettier + ESLint, but only reports formatting / linting issues and does not edit any files yet
-  - Run by our GitHub Actions in `.github/workflows/main.yml`, so that each PR gets its formatting / linting automatically checked before merge
+  - Run via GitHub Actions in `.github/workflows/main.yml`, so that each PR gets its formatting / linting automatically checked before merge
 
 ### App Compilation Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Cross Platform Mobile app for the OSU Men's Golf Team.
 - [React Native Paper](https://reactnativepaper.com/)
 - [Gorhom/bottom-sheet](https://ui.gorhom.dev/components/bottom-sheet/)
 - [React Native SVG Charts](https://www.npmjs.com/package/react-native-svg-charts)
-- [Expo Go](https://expo.dev/)
+- [Expo](https://expo.dev/)
 - [TanStack Query](https://tanstack.com/query/latest/docs/framework/react/overview)
 - [Firestore](https://firebase.google.com/docs/firestore)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Cross Platform Mobile app for the OSU Men's Golf Team.
 
 - [React Native](https://reactnative.dev/)
 - [React Native Paper](https://reactnativepaper.com/)
+- [Gorhom/bottom-sheet](https://ui.gorhom.dev/components/bottom-sheet/)
 - [React Native SVG Charts](https://www.npmjs.com/package/react-native-svg-charts)
 - [Expo Go](https://expo.dev/)
 - [TanStack Query](https://tanstack.com/query/latest/docs/framework/react/overview)

--- a/README.md
+++ b/README.md
@@ -37,12 +37,9 @@ See [package.json](package.json) for more details on libraries used
 
 ## Database Specifications
 
-Info below subject to change
-
 - Database Schema: [db_spec.jsonc](db_spec.jsonc)
-  - The current database on Firestore, as well as the local test data in [drill_data.json](drill_data.json), follows the schema starting on line 29 (`teams` object) of `db_spec.jsonc`
-    - May be moving drill attempts out of `teams` and into a separate data object soon
-- Currently, some pages in profile, team, drill submission still use the local data from `drill_data.json`, but the rest are connected to Firestore
+  - Overview / template of database design and structure
+- NOTE: The latest database / database specifications are now on Google Firestore (not public)
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See [package.json](package.json) for more details on libraries used
 
 ### Architecture Diagram
 
-![architectural_diagram](https://i.imgur.com/Wy0O2iL.png)
+![architectural_diagram](https://i.imgur.com/t1Y4ARm.png)
 
 ## Design References
 


### PR DESCRIPTION
Some minor fixes for readme headings, grammar, nomenclature

Main issue fixed: I had `yarn android` under "ios build instructions section" by accident. Now corrected to be `yarn ios`