### PR TITLE
fix: address runtime error by relocating moment-timezone to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "expo-system-ui": "~3.0.4",
     "firebase": "^10.8.0",
     "react": "18.2.0",
+    "moment-timezone": "^0.5.45",
     "react-dom": "18.2.0",
     "react-native": "0.74.1",
     "react-native-dropdown-picker": "^5.4.6",
@@ -75,7 +76,6 @@
     "eslint-plugin-react": "^7.34.2",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-scope": "^8.0.1",
-    "moment-timezone": "^0.5.45",
     "prettier": "^3.2.5",
     "prettier-plugin-organize-imports": "^3.2.4"
   },


### PR DESCRIPTION
## Summary

Fixed an issue preventing the iOS simulator from running the app by moving the `moment-timezone` package to the correct section in `package.json`:

<img width="553" alt="bundlingFailed" src="https://github.com/user-attachments/assets/36762e7a-34c0-4b7c-addc-3de7b81bbda9">

## Changes Made

- Relocated `moment-timezone` from the `devDependencies` section to the `dependencies` section in `package.json`.

## Reason for Changes

The `moment-timezone` package was incorrectly listed under `devDependencies`, which caused the app to fail at runtime in the production environment since it wasn't available.