### PR TITLE
IWB 0: Fixed cached login still being redirected to choose team because of verified email

### DIFF
--- a/context/Auth.js
+++ b/context/Auth.js
@@ -36,7 +36,7 @@ export const AuthProvider = ({ children }) => {
   const [currentUserId, setCurrentUserId] = useState(null);
   const [currentUserInfo, setCurrentUserInfo] = useState(null);
   const [currentTeamId, setCurrentTeamId] = useState("1");
-  const [currentUserVerified, setCurrentUserVerified] = useState(false);
+  const [currentUserVerified, setCurrentUserVerified] = useState(true);
 
   useProtectedRoute(currentUserId);
 


### PR DESCRIPTION
Video of app being reloaded while having login cached. The user is able to log in automatically, but when useUserInfo is called, userVerification will be false because its value is set to default to false and the idToken didn't change.
Fixed by changing default userVerification to true. Verified email flow still works as normal.
https://github.com/user-attachments/assets/7233688b-6497-4996-b510-1512f22d2c49

