### PR TITLE
handle newly logged in user not having perms

### DIFF
--- a/context/Alert.js
+++ b/context/Alert.js
@@ -17,10 +17,12 @@ export const AlertProvider = ({ children }) => {
 
   const [snackbarVisible, setSnackbarVisible] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState("");
+
   return (
     <AlertContext.Provider
       value={{
         showDialog: (title, message) => {
+          if (title === "Error" && message === "permission-denied") return; //for initial sign in. do this or change the rules
           setDialogTitle(title);
           setDialogMessage(message);
           setDialogVisible(true);

--- a/dbOperations/hooks/useUserInfo.js
+++ b/dbOperations/hooks/useUserInfo.js
@@ -11,6 +11,7 @@ import {
 } from "firebase/firestore";
 import { useAuthContext } from "~/context/Auth";
 import { db } from "~/firebaseConfig";
+import { getErrorString } from "~/Utility";
 
 export const useUserInfo = ({
   userId = null,
@@ -28,10 +29,20 @@ export const useUserInfo = ({
     queryFn: async () => {
       console.log("fetching userInfo: ", { userId, role });
       if (userId) {
-        const querySnapshot = await getDoc(
-          doc(db, "teams", currentTeamId, "users", userId),
-        );
-        const data = querySnapshot.data();
+        let data;
+        try {
+          const querySnapshot = await getDoc(
+            doc(db, "teams", currentTeamId, "users", userId),
+          );
+          data = querySnapshot.data();
+        } catch (e) {
+          if (getErrorString(e) === "permission-denied") {
+            data = undefined;
+          } else {
+            throw e;
+          }
+          console.log("e", getErrorString(e));
+        }
 
         if (!data || !currentUserVerified) {
           if (currentUserId === userId) {


### PR DESCRIPTION
The firestore rule right now is only people in the team would be able to see the contents in the team. However, a newly signed up user would first be navigated to the Assignments page and then the ChooseTeam page. The Assignments page would error out with "permission-denied" and the user won't be navigated to ChooseTeam. This PR handles this explicitly.