### PR TITLE
Only the user or coaches can clear old assignments

### DIFF
--- a/dbOperations/hooks/useUserInfo.js
+++ b/dbOperations/hooks/useUserInfo.js
@@ -74,11 +74,15 @@ export const useUserInfo = ({
             ...data,
             assigned_data: filteredAssignedData,
           };
-          await updateDoc(
-            doc(db, "teams", currentTeamId, "users", userId),
-            updatedData,
-          );
-          return updatedData;
+          try {
+            await updateDoc(
+              doc(db, "teams", currentTeamId, "users", userId),
+              updatedData,
+            );
+            return updatedData;
+          } catch (e) {
+            console.log("can't clear old assignments", getErrorString(e));
+          }
         }
         return data;
       } else if (role) {


### PR DESCRIPTION
If this is not in place, firestore rules would have to allow user data update from any logged in user