### PR TITLE
Add - Missing Abbreviations for Stats

### DIFF
--- a/Constants.js
+++ b/Constants.js
@@ -40,6 +40,8 @@ const shortTitle = {
   proxHoleAverage: "PHA",
   sideLandingAverage: "SLA",
   sideLandingTotal: "SLT",
+  rightSideLandingAverage: "AMR",
+  leftSideLandingAverage: "AML",
 };
 
 const prettyRole = {


### PR DESCRIPTION
## Description:
A simple PR to add in missing abbreviations for Stats page

> closes #331 

## Screenshot:
![image](https://github.com/user-attachments/assets/4715f24f-8afa-41e6-9b17-8cf6d0e1339a)
![image](https://github.com/user-attachments/assets/f097e856-90a9-4167-b6cc-a7675c863b72)

